### PR TITLE
Fix website

### DIFF
--- a/content/_index/hero.md
+++ b/content/_index/hero.md
@@ -14,12 +14,11 @@ subtitle = "EMF.cloud - evolve your modeling tools to the web!"
 
 [asset]
   image = "diagramanimated.gif"
-  width = "500px" # optional - will default to image width
-  height = "150px" # optional - will default to image height
+  width = "600px" # optional - will default to image width
 
 [[buttons]]
-  text = "Features"
-  url = "#features"
+  text = "Components"
+  url = "#components"
   color = "primary"
 
 [[buttons]]


### PR DESCRIPTION
## Update to latest syna
A hugo update between 0.68 and 0.73 contained incompatible changes with
the syna theme. We now update to the latest syna master.

Also the syna theme was updated to properly handle custom paths.
Therefore we no longer need our custom path fix and can go back to
consume the regular syna version.

## Fix Landing Page
Resize the top gif and replace the broken "Features" button.

The top gif was set to 150px height which seamingly was ignored before
and was now honored with the hugo & syna update. The gif is now sized
appropriatly.

There was no '#features' anchor on the page, which lead to the
"Features" button being broken. The button is now replaced with a
"Components" button.
