### PR TITLE
Fix broken documentation links

### DIFF
--- a/content/_index/coffeeeditorlinks/blogpost.md
+++ b/content/_index/coffeeeditorlinks/blogpost.md
@@ -7,4 +7,4 @@ weight = 30
   url = "https://eclipsesource.com/blogs/2020/07/24/a-web-based-modeling-tool-based-on-eclipse-theia/"
 +++
 
-If you want to learn more about the coffee editor, please see [this article, describing the details](https://eclipsesource.com/blogs/2020/07/24/a-web-based-modeling-tool-based-on-eclipse-theia/) or watch [this video](https://www.youtube.com/watch?v=2tRJpC8IIiI). Alternativly, you find an overview of the available features below.
+If you want to learn more about the coffee editor, please see [this article, describing the details](https://eclipsesource.com/blogs/2020/07/24/a-web-based-modeling-tool-based-on-eclipse-theia/) or watch [this video](https://www.youtube.com/watch?v=2tRJpC8IIiI). Alternatively, you find an overview of the available features below.

--- a/content/documentation/content.md
+++ b/content/documentation/content.md
@@ -5,13 +5,19 @@ weight = 100
 +++
 
 <span style='display:block; text-align: center;'>
+
 We are continuously improving our documentation, in case you miss something, please [contact us]({{< relref  "/contact" >}})
+
 </span>
 
 <span style='display:block; text-align: center;'>
+
 Technical documentation can be found on the respective GitHub page of the EMF.cloud component (see below). Additionally, please see <a href="https://docs.google.com/presentation/d/e/2PACX-1vQVxtf1OFWq7JTldMcjuApsW47N6IlCGfuitGEyOE-MqeNde99Dm5-JO0XJG9R54NIYsoxq1AK6y7mW/pub?start=false&loop=false&delayms=3000">this talk introducing EMF.cloud at EclipseCon 2019</a>
+
 </span>
 
 <span style='display:block; text-align: center;'>
+
 See [here for the available support options]({{< relref  "/support" >}})
+
 </span>

--- a/content/support/examples/professionalsupport.md
+++ b/content/support/examples/professionalsupport.md
@@ -13,7 +13,7 @@ weight = 20
 **Code examples**\
 **Advanced topics covered**\
 **Private channel available (NDA)**\
-**Feature prioritization**\
+**Feature prioritization**
 
 Starts from 1,695.00 €: **[Contact us for details](mailto:munich@eclipsesource.com)**\
 10 hours professional support\


### PR DESCRIPTION
Markdown content in HTML elements is only processed by Goldmark
when surrounded by blank lines. This is now done for the
documentation content links.

Also fixes a typo in blogpost.md