### PR TITLE
Change URLs from eclipse.org to eclipse.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sources of the EMF Cloud Website
 
-This repository hosts the sources of [eclipse.org/emfcloud](https://www.eclipse.org/emfcloud).
+This repository hosts the sources of [eclipse.dev/emfcloud](https://www.eclipse.dev/emfcloud).
 We use the [Syna](https://github.com/okkur/syna) thema for [Hugo](https://gohugo.io/)
 
 Please check the [Syna documentation](https://about.okkur.org/syna/docs/). The Syna theme heavily works with fragments, therefore the development differs a bit from a "normal" Hugo website.

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://www.eclipse.org/emfcloud"
+baseURL = "https://www.eclipse.dev/emfcloud"
 DefaultContentLanguage = "en"
 title = "EMF.cloud"
 theme = "syna"
@@ -86,7 +86,7 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 15
 
 [[menu.footer]]
-  url = "https://eclipse.org/glsp"
+  url = "https://eclipse.dev/glsp"
   name = "Eclipse GLSP"
   weight = 10
 
@@ -96,7 +96,7 @@ lastmod = ["lastmod", ":git", "date"]
   weight = 30
 
 [[menu.footer]]
-  url = "https://eclipse.org/che"
+  url = "https://eclipse.dev/che"
   name = "Eclipse Che"
   weight = 50
 

--- a/content/_index/coffeeeditorfeatures/diagrameditor.md
+++ b/content/_index/coffeeeditorfeatures/diagrameditor.md
@@ -6,4 +6,4 @@ weight = 30
   icon = "fas fa-project-diagram"
 +++
 
-The coffee editor provides a graphical diagram editor. The example editor allows specifying the behavior of a coffee maching using a flow chart like notation. The diagram editor is based on [the graphical language server platform (Eclipse GLSP)](https://www.eclipse.org/glsp/). Double click the file "superbrewer3000.coffeenotation" in the coffee editor to try out the diagram editor!
+The coffee editor provides a graphical diagram editor. The example editor allows specifying the behavior of a coffee maching using a flow chart like notation. The diagram editor is based on [the graphical language server platform (Eclipse GLSP)](https://www.eclipse.dev/glsp/). Double click the file "superbrewer3000.coffeenotation" in the coffee editor to try out the diagram editor!

--- a/content/_index/coffeeeditorfeatures/textualDSL.md
+++ b/content/_index/coffeeeditorfeatures/textualDSL.md
@@ -6,4 +6,4 @@ weight = 40
   icon = "fas fa-indent"
 +++
 
-The coffee editor integrates a textual DSL. A corresponding code editor supports syntaxt highlighting and auto completion. The DSL editor is based on [Xtext](https://www.eclipse.org/Xtext/). Double click the file "superbrewer3000.wfconfig" in the coffee editor to try out the textual DSl!
+The coffee editor integrates a textual DSL. A corresponding code editor supports syntaxt highlighting and auto completion. The DSL editor is based on [Xtext](https://www.eclipse.dev/Xtext/). Double click the file "superbrewer3000.wfconfig" in the coffee editor to try out the textual DSl!

--- a/content/_index/projects/glsp.md
+++ b/content/_index/projects/glsp.md
@@ -4,7 +4,7 @@ weight = 10
 
 [asset]
   icon = "fas fa-project-diagram"
-  url = "https://www.eclipse.org/glsp/"
+  url = "https://www.eclipse.dev/glsp/"
 +++
 
-The [Graphical Language Server Platform (GLSP)](https://www.eclipse.org/glsp/) supports the development of web-based diagram editors. It transfer the advantages of the language server protocol (LSP) to graphical modeling languages. GLSP is well integrated with other EMF.cloud components, such as the model server and is used as a basis for the coffee editor and the Theia Ecore extension.
+The [Graphical Language Server Platform (GLSP)](https://www.eclipse.dev/glsp/) supports the development of web-based diagram editors. It transfer the advantages of the language server protocol (LSP) to graphical modeling languages. GLSP is well integrated with other EMF.cloud components, such as the model server and is used as a basis for the coffee editor and the Theia Ecore extension.

--- a/content/_index/projects/jsonforms.md
+++ b/content/_index/projects/jsonforms.md
@@ -7,4 +7,4 @@ weight = 20
   url = "https://jsonforms.io"
 +++
 
-[JSON Forms](https://jsonforms.io) is a framework for the efficient development of form-based UIs. These allow to display and modify model instances in data-centric UIs such as trees, tables and field editors. JSON Forms is the web-version of [EMF Forms](https://www.eclipse.org/ecp/emfforms/). It is the basis of the tree-master-detail model editor of the coffee editor.
+[JSON Forms](https://jsonforms.io) is a framework for the efficient development of form-based UIs. These allow to display and modify model instances in data-centric UIs such as trees, tables and field editors. JSON Forms is the web-version of [EMF Forms](https://www.eclipse.dev/ecp/emfforms/). It is the basis of the tree-master-detail model editor of the coffee editor.

--- a/content/documentation/projecttemplates.md
+++ b/content/documentation/projecttemplates.md
@@ -6,7 +6,7 @@ background = "white"
 +++
 <span style='display:block; text-align: center;'>
 
-To get you started quickly, we provide project templates for the most popular choices including EMF.cloud and [GLSP](https://www.eclipse.org/glsp/documentation/gettingstarted/) components.
+To get you started quickly, we provide project templates for the most popular choices including EMF.cloud and [GLSP](https://www.eclipse.dev/glsp/documentation/gettingstarted/) components.
 
 Please see the following project-template and follow its README file.
 


### PR DESCRIPTION
More information on this migration can be found at https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3069